### PR TITLE
Update pm-tools documentation with new CLI commands and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,50 +163,88 @@ The DOI link is clickable in your editor but removed in the final output.
 
 ## Integration with pm-tools
 
-[pm-tools](https://github.com/lescientifik/pm-tools) is a companion CLI suite for searching and fetching PubMed articles. Together, they provide a complete workflow for scientific writing.
+[pm-tools](https://github.com/lescientifik/pm-tools) is a companion CLI for searching, fetching, and analyzing PubMed articles. Together, they provide a complete workflow from literature search to formatted manuscript.
+
+### Install pm-tools
+
+```bash
+uv tool install git+https://github.com/lescientifik/pm-tools.git
+```
+
+Requires Python >= 3.12 and [uv](https://docs.astral.sh/uv/). All `pm` commands support `--help`.
 
 ### Search, cite, and format in one pipeline
 
 ```bash
 # Search PubMed and generate bibliography
-pm-search "CRISPR gene therapy" | pm-fetch | pm-cite > refs.jsonl
+pm search "CRISPR gene therapy" | pm fetch | pm cite > refs.jsonl
 
 # Format your article
 csl-tools process article.md --bib refs.jsonl --csl nature.csl -o article.html
+```
+
+### Quick search shortcut
+
+```bash
+# pm quick runs the full pipeline (search | fetch | parse) in one command
+pm quick "covid vaccine" --max 50 > articles.jsonl
 ```
 
 ### Build a bibliography from PMIDs
 
 ```bash
 # Generate CSL-JSON for specific articles
-pm-cite 33024307 29355051 38461394 > refs.jsonl
+pm cite 33024307 29355051 38461394 > refs.jsonl
 
 # Use in your document with [@pmid:33024307] syntax
 csl-tools process article.md --bib refs.jsonl --csl apa.csl -o output.html
-```
-
-### Interactive article selection with fzf
-
-```bash
-# Search, preview, select articles interactively, then generate citations
-pm-search "PET imaging biomarkers" | pm-fetch | pm-parse | \
-  pm-show --fzf | pm-cite > refs.jsonl
 ```
 
 ### Complete research workflow
 
 ```bash
 # 1. Search and save parsed results for offline use
-pm-search "immunotherapy melanoma" | pm-fetch | pm-parse > articles.jsonl
+pm search "immunotherapy melanoma" | pm fetch | pm parse > articles.jsonl
 
 # 2. Filter by year and journal
-pm-filter --year 2023-2025 --journal "Nature" < articles.jsonl > filtered.jsonl
+pm filter --year 2023-2025 --journal "Nature" < articles.jsonl > filtered.jsonl
 
 # 3. Generate citations for selected articles
-jq -r '.pmid' filtered.jsonl | pm-cite > refs.jsonl
+jq -r '.pmid' filtered.jsonl | pm cite > refs.jsonl
 
 # 4. Format your manuscript
 csl-tools process manuscript.md --bib refs.jsonl --csl cell.csl -o manuscript.html
+```
+
+### Download Open Access PDFs
+
+```bash
+# Preview what's available
+pm search "CRISPR" | pm fetch | pm parse | pm download --dry-run
+
+# Download to a directory (uses PMC, then Unpaywall as fallback)
+pm search "CRISPR" | pm fetch | pm parse | pm download --output-dir ./pdfs/
+```
+
+### Track search evolution with pm diff
+
+```bash
+# Compare two search snapshots to find new articles
+pm quick "CRISPR cancer" > baseline_v1.jsonl
+# ... later ...
+pm quick "CRISPR cancer" > baseline_v2.jsonl
+pm diff baseline_v1.jsonl baseline_v2.jsonl | jq -r 'select(.status=="added") | .pmid'
+```
+
+### Audit trail
+
+```bash
+# Initialize audit tracking in your project
+pm init
+
+# View history of all pm operations
+pm audit
+pm audit --searches
 ```
 
 ## PubMed Workflow (without pm-tools)

--- a/exemples/crispr-gene-editing-therapy/README.md
+++ b/exemples/crispr-gene-editing-therapy/README.md
@@ -7,7 +7,7 @@ Démonstration de la pipeline complète `pm-tools` → `csl-tools`.
 | Fichier | Description |
 |---------|-------------|
 | `article.md` | Article original avec citations `[@pmid:...]` |
-| `refs.jsonl` | Références CSL-JSON (via `pm-cite`) |
+| `refs.jsonl` | Références CSL-JSON (via `pm cite`) |
 | `apa.csl` | Style de citation APA 7th edition |
 | `output.md` | Article final avec citations formatées et bibliographie |
 
@@ -15,10 +15,10 @@ Démonstration de la pipeline complète `pm-tools` → `csl-tools`.
 
 ```bash
 # 1. Recherche PubMed
-pm-search --max 5 "CRISPR gene editing therapy 2024"
+pm search --max 5 "CRISPR gene editing therapy 2024"
 
 # 2. Récupération des citations
-echo -e "41524770\n41524478\n41481737\n41476860\n41465342" | pm-cite > refs.jsonl
+pm cite 41524770 41524478 41481737 41476860 41465342 > refs.jsonl
 
 # 3. Traitement avec csl-tools
 csl-tools process article.md --bib refs.jsonl --csl apa.csl -o output.md


### PR DESCRIPTION
## Summary
Updated the README documentation to reflect changes in the pm-tools CLI interface and added comprehensive examples of new features and workflows.

## Key Changes

- **Updated command syntax**: Changed from hyphenated commands (e.g., `pm-search`, `pm-fetch`) to space-separated subcommands (e.g., `pm search`, `pm fetch`) to match the current CLI interface
- **Added installation instructions**: Included setup guide for pm-tools using `uv tool install` with Python >= 3.12 requirement
- **New feature documentation**:
  - `pm quick` command for running the full pipeline (search | fetch | parse) in one command
  - `pm download` command for downloading Open Access PDFs from PMC and Unpaywall
  - `pm diff` command for comparing search snapshots and tracking new articles
  - `pm init` and `pm audit` commands for tracking project history
- **Reorganized examples**: Removed the interactive `pm-show --fzf` example and replaced it with more practical workflows
- **Updated example files**: Modified the French example documentation to use the new command syntax and simplified the citation generation workflow
- **Enhanced workflow documentation**: Added more realistic multi-step examples showing filtering, diffing, and PDF downloading capabilities

## Notable Details

The changes maintain backward compatibility in documentation while reflecting the actual current state of the pm-tools CLI. All command examples now use the consistent `pm <subcommand>` pattern rather than the previous `pm-<subcommand>` format.

https://claude.ai/code/session_01Jmk7xbpSyqJETkajK8Rgd3